### PR TITLE
Uber shaders

### DIFF
--- a/d3d8to11.sln.DotSettings
+++ b/d3d8to11.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=emissive/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/d3d8to11.sln.DotSettings
+++ b/d3d8to11.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=emissive/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=emissive/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=uber/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/d3d8to11/ShaderCompilationQueue.cpp
+++ b/d3d8to11/ShaderCompilationQueue.cpp
@@ -25,15 +25,10 @@ bool ShaderCompilationQueueEntry::operator!=(const ShaderCompilationQueueEntry& 
 
 ShaderCompilationQueue::ShaderCompilationQueue(size_t thread_count)
 	: _thread_count(thread_count),
-	  _running(true),
-	  _threads(_thread_count),
-	  _functions(),
-	  _queue()
+	  _running(false),
+	  _threads(_thread_count)
 {
-	for (std::thread& t : _threads)
-	{
-		t = std::thread(&ShaderCompilationQueue::work_thread, this);
-	}
+	start();
 }
 
 ShaderCompilationQueue::~ShaderCompilationQueue()
@@ -80,7 +75,7 @@ void ShaderCompilationQueue::start()
 
 void ShaderCompilationQueue::shutdown()
 {
-	if (_running == true)
+	if (_running == false)
 	{
 		return;
 	}

--- a/d3d8to11/ShaderCompilationQueue.cpp
+++ b/d3d8to11/ShaderCompilationQueue.cpp
@@ -1,0 +1,149 @@
+#include "stdafx.h"
+#include "ShaderCompilationQueue.h"
+
+ShaderCompilationQueueEntry::ShaderCompilationQueueEntry()
+	: type(ShaderCompilationType::none),
+	  flags(ShaderFlags::none)
+{
+}
+
+ShaderCompilationQueueEntry::ShaderCompilationQueueEntry(ShaderCompilationType type, ShaderFlags::type flags)
+	: type(type),
+	  flags(flags)
+{
+}
+
+bool ShaderCompilationQueueEntry::operator==(const ShaderCompilationQueueEntry& rhs) const
+{
+	return type == rhs.type && flags == rhs.flags;
+}
+
+bool ShaderCompilationQueueEntry::operator!=(const ShaderCompilationQueueEntry& rhs) const
+{
+	return type != rhs.type || flags != rhs.flags;
+}
+
+static size_t thread_count = 0;
+static size_t enqueued_items = 0;
+
+ShaderCompilationQueue::ShaderCompilationQueue(size_t thread_count)
+	: _thread_count(thread_count),
+	  _running(true),
+	  _threads(_thread_count),
+	  _functions(),
+	  _queue()
+{
+	for (std::thread& t : _threads)
+	{
+		t = std::thread(&ShaderCompilationQueue::work_thread, this);
+	}
+}
+
+ShaderCompilationQueue::~ShaderCompilationQueue()
+{
+	shutdown();
+}
+
+void ShaderCompilationQueue::enqueue(ShaderCompilationType type, ShaderFlags::type flags, CompilationFunction function)
+{
+	std::lock_guard guard(_mutex);
+
+	auto key = ShaderCompilationQueueEntry(type, flags);
+	const auto it = _functions.find(key);
+
+	if (it != _functions.end())
+	{
+		return;
+	}
+
+	++enqueued_items;
+	_queue.emplace(key);
+	_functions[key] = std::move(function);
+	_condition.notify_one();
+
+	std::stringstream ss;
+	ss << "active threads: " << thread_count << "; enqueued shaders: " << enqueued_items << "\n";
+	OutputDebugStringA(ss.str().c_str());
+}
+
+void ShaderCompilationQueue::start()
+{
+	if (_running == true)
+	{
+		return;
+	}
+
+	_running = true;
+
+	for (std::thread& t : _threads)
+	{
+		t = std::thread(&ShaderCompilationQueue::work_thread, this);
+	}
+}
+
+void ShaderCompilationQueue::shutdown()
+{
+	if (_running == true)
+	{
+		return;
+	}
+
+	_running = false;
+	_condition.notify_all();
+
+	for (std::thread& t : _threads)
+	{
+		t.join();
+	}
+}
+
+void ShaderCompilationQueue::work_thread()
+{
+	while (_running == true)
+	{
+		ShaderCompilationQueueEntry key;
+		CompilationFunction function;
+
+		{
+			if (_running == false)
+			{
+				break;
+			}
+
+			std::unique_lock lock(_mutex);
+
+			if (_queue.empty())
+			{
+				_condition.wait(lock);
+
+				if (_queue.empty())
+				{
+					continue;
+				}
+			}
+
+			++thread_count;
+			std::stringstream ss;
+			ss << "active threads: " << thread_count << "; enqueued shaders: " << enqueued_items << "\n";
+			OutputDebugStringA(ss.str().c_str());
+
+			key = _queue.front();
+			_queue.pop();
+
+			function = std::move(_functions[key]);
+		}
+
+		function(key);
+
+		{
+			std::unique_lock lock(_mutex);
+			_functions.erase(key);
+
+			--enqueued_items;
+			--thread_count;
+			std::stringstream ss;
+			ss << "active threads: " << thread_count << "; enqueued shaders: " << enqueued_items << "\n";
+			OutputDebugStringA(ss.str().c_str());
+		}
+	}
+}

--- a/d3d8to11/ShaderCompilationQueue.h
+++ b/d3d8to11/ShaderCompilationQueue.h
@@ -54,6 +54,9 @@ class ShaderCompilationQueue
 	std::unordered_map<ShaderCompilationQueueEntry, CompilationFunction> _functions;
 	std::queue<ShaderCompilationQueueEntry> _queue;
 
+	size_t _active_threads = 0;
+	size_t _enqueued_count = 0;
+
 public:
 	explicit ShaderCompilationQueue(size_t thread_count);
 	~ShaderCompilationQueue();
@@ -61,6 +64,9 @@ public:
 	void enqueue(ShaderCompilationType type, ShaderFlags::type flags, CompilationFunction function);
 	void start();
 	void shutdown();
+
+	[[nodiscard]] size_t active_threads() const;
+	[[nodiscard]] size_t enqueued_count() const;
 
 private:
 	void work_thread();

--- a/d3d8to11/ShaderCompilationQueue.h
+++ b/d3d8to11/ShaderCompilationQueue.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <queue>
+#include <unordered_map>
+#include <thread>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+
+#include "hash_combine.h"
+
+enum class ShaderCompilationType
+{
+	none,
+	vertex,
+	pixel
+};
+
+struct ShaderCompilationQueueEntry
+{
+	ShaderCompilationType type;
+	ShaderFlags::type flags;
+
+	ShaderCompilationQueueEntry();
+	ShaderCompilationQueueEntry(ShaderCompilationType type, ShaderFlags::type flags);
+
+	bool operator==(const ShaderCompilationQueueEntry& rhs) const;
+	bool operator!=(const ShaderCompilationQueueEntry& rhs) const;
+};
+
+namespace std
+{
+	template <>
+	struct hash<ShaderCompilationQueueEntry>
+	{
+		std::size_t operator()(const ShaderCompilationQueueEntry& s) const noexcept
+		{
+			size_t h = std::hash<size_t>()(static_cast<size_t>(s.type));
+			hash_combine(h, s.flags);
+			return h;
+		}
+	};
+}
+
+class ShaderCompilationQueue
+{
+	using CompilationFunction = std::function<void(const ShaderCompilationQueueEntry& entry)>;
+
+	const size_t _thread_count;
+	std::atomic_bool _running;
+	std::condition_variable _condition;
+	std::mutex _mutex;
+	std::vector<std::thread> _threads;
+	std::unordered_map<ShaderCompilationQueueEntry, CompilationFunction> _functions;
+	std::queue<ShaderCompilationQueueEntry> _queue;
+
+public:
+	explicit ShaderCompilationQueue(size_t thread_count);
+	~ShaderCompilationQueue();
+
+	void enqueue(ShaderCompilationType type, ShaderFlags::type flags, CompilationFunction function);
+	void start();
+	void shutdown();
+
+private:
+	void work_thread();
+};

--- a/d3d8to11/ShaderFlags.cpp
+++ b/d3d8to11/ShaderFlags.cpp
@@ -1,0 +1,19 @@
+#include "stdafx.h"
+#include "ShaderFlags.h"
+
+ShaderFlags::type ShaderFlags::sanitize(type flags)
+{
+	flags &= mask;
+
+	if (flags & rs_lighting && !(flags & D3DFVF_NORMAL))
+	{
+		flags &= ~rs_lighting;
+	}
+
+	if (flags & rs_oit && !(flags & rs_alpha))
+	{
+		flags &= ~rs_oit;
+	}
+
+	return flags;
+}

--- a/d3d8to11/ShaderFlags.h
+++ b/d3d8to11/ShaderFlags.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstdint>
+
+struct ShaderFlags
+{
+	using type = uint64_t;
+
+	enum T : type
+	{
+		none,
+		rs_lighting      = 0b00001000'00000000'00000000'00000000'00000000'00000000'00000000'00000000,
+		rs_specular      = 0b00010000'00000000'00000000'00000000'00000000'00000000'00000000'00000000,
+		rs_alpha         = 0b00100000'00000000'00000000'00000000'00000000'00000000'00000000'00000000,
+		rs_fog           = 0b01000000'00000000'00000000'00000000'00000000'00000000'00000000'00000000,
+		rs_oit           = 0b10000000'00000000'00000000'00000000'00000000'00000000'00000000'00000000,
+		fvf_position     = 0b00000000'00000000'00000000'00000000'00000000'00000000'00000000'00001110,
+		fvf_fields       = 0b00000000'00000000'00000000'00000000'00000000'00000000'00000000'11110000,
+		fvf_texcount     = 0b00000000'00000000'00000000'00000000'00000000'00000000'00001111'00000000,
+		fvf_lastbeta     = 0b00000000'00000000'00000000'00000000'00000000'00000000'00010000'00000000,
+		fvf_texfmt       = 0b00000000'00000000'00000000'00000000'11111111'11111111'00000000'00000000,
+		stage_count_mask = 0b00000000'00000000'00000000'00001111'00000000'00000000'00000000'00000000,
+		fvf_mask         = fvf_position | fvf_fields | fvf_texcount | fvf_lastbeta | fvf_texfmt,
+		rs_mask          = rs_lighting | rs_specular | rs_alpha | rs_fog | rs_oit,
+		mask             = rs_mask | fvf_mask | stage_count_mask,
+		count
+	};
+
+	static constexpr type stage_count_shift = 32;
+
+	static constexpr type light_sanitize_flags = rs_lighting | rs_specular |
+		D3DFVF_DIFFUSE | D3DFVF_SPECULAR | D3DFVF_NORMAL | D3DFVF_XYZRHW;
+
+#ifdef PER_PIXEL
+	// TODO
+#else
+	static constexpr type vs_mask = rs_lighting | rs_specular | fvf_mask;
+	static constexpr type ps_mask = stage_count_mask | rs_mask | light_sanitize_flags;
+
+	static constexpr type uber_vs_mask = fvf_mask;
+	static constexpr type uber_ps_mask = stage_count_mask | (light_sanitize_flags & ~rs_mask);
+#endif
+
+	static type sanitize(type flags);
+};

--- a/d3d8to11/cbuffers.cpp
+++ b/d3d8to11/cbuffers.cpp
@@ -1,15 +1,58 @@
 #include "stdafx.h"
 #include "cbuffers.h"
 
+void UberShaderFlagsBuffer::write(CBufferBase& cbuf) const
+{
+	cbuf << rs_lighting
+	     << rs_specular
+	     << rs_alpha
+	     << rs_fog
+	     << rs_oit;
+}
+
+bool UberShaderFlagsBuffer::dirty() const
+{
+	return rs_lighting.dirty() ||
+	       rs_specular.dirty() ||
+	       rs_alpha.dirty() ||
+	       rs_fog.dirty() ||
+	       rs_oit.dirty();
+}
+
+void UberShaderFlagsBuffer::clear()
+{
+	rs_lighting.clear();
+	rs_specular.clear();
+	rs_alpha.clear();
+	rs_fog.clear();
+	rs_oit.clear();
+}
+
+void UberShaderFlagsBuffer::mark()
+{
+	rs_lighting.mark();
+	rs_specular.mark();
+	rs_alpha.mark();
+	rs_fog.mark();
+	rs_oit.mark();
+}
+
 void PerSceneBuffer::write(CBufferBase& cbuf) const
 {
-	cbuf << this->view_matrix << this->projection_matrix << this->screen_dimensions << this->view_position << this->buffer_len;
+	cbuf << this->view_matrix
+	     << this->projection_matrix
+	     << this->screen_dimensions
+	     << this->view_position
+	     << this->buffer_len;
 }
 
 bool PerSceneBuffer::dirty() const
 {
-	return view_matrix.dirty() || projection_matrix.dirty() ||
-	       screen_dimensions.dirty() || view_position.dirty() || buffer_len.dirty();
+	return view_matrix.dirty() ||
+	       projection_matrix.dirty() ||
+	       screen_dimensions.dirty() ||
+	       view_position.dirty() ||
+	       buffer_len.dirty();
 }
 
 void PerSceneBuffer::clear()
@@ -86,8 +129,13 @@ bool PerModelBuffer::dirty() const
 		}
 	}
 
-	return draw_call.dirty() || world_matrix.dirty() || wv_matrix_inv_t.dirty() ||
-	       material.dirty() || material_sources.dirty() || ambient.dirty() || color_vertex.dirty();
+	return draw_call.dirty() ||
+	       world_matrix.dirty() ||
+	       wv_matrix_inv_t.dirty() ||
+	       material.dirty() ||
+	       material_sources.dirty() ||
+	       ambient.dirty() ||
+	       color_vertex.dirty();
 }
 
 void PerModelBuffer::clear()
@@ -125,8 +173,8 @@ void PerModelBuffer::mark()
 void PerPixelBuffer::write(CBufferBase& cbuf) const
 {
 	cbuf << src_blend << dst_blend << blend_op
-		<< fog_mode << fog_start << fog_end << fog_density << fog_color
-		<< alpha_reject << alpha_reject_mode << alpha_reject_threshold << texture_factor;
+	     << fog_mode << fog_start << fog_end << fog_density << fog_color
+	     << alpha_reject << alpha_reject_mode << alpha_reject_threshold << texture_factor;
 }
 
 bool PerPixelBuffer::dirty() const

--- a/d3d8to11/cbuffers.h
+++ b/d3d8to11/cbuffers.h
@@ -7,6 +7,22 @@
 #include "Material.h"
 #include "defs.h"
 
+class UberShaderFlagsBuffer : public ICBuffer, dirty_impl
+{
+public:
+	dirty_t<bool> rs_lighting;
+	dirty_t<bool> rs_specular;
+	dirty_t<bool> rs_alpha;
+	dirty_t<bool> rs_fog;
+	dirty_t<bool> rs_oit;
+
+	void write(CBufferBase& cbuf) const override;
+
+	[[nodiscard]] bool dirty() const override;
+	void clear() override;
+	void mark() override;
+};
+
 class PerSceneBuffer : public ICBuffer, dirty_impl
 {
 public:

--- a/d3d8to11/composite.hlsl
+++ b/d3d8to11/composite.hlsl
@@ -1,14 +1,14 @@
 #include "include.hlsli"
 
 // copy-pasted -- bad
-cbuffer PerSceneBuffer : register(b0)
+cbuffer PerSceneBuffer : register(b1)
 {
 	matrix view_matrix;
 	matrix projection_matrix;
 	float2 screen_dimensions;
 	float3 view_position;
 	uint   buffer_len;
-};
+}
 
 /*
 	This shader draws a full screen triangle onto

--- a/d3d8to11/d3d8to11.hlsl
+++ b/d3d8to11/d3d8to11.hlsl
@@ -3,7 +3,7 @@
 
 #include "include.hlsli"
 
-#ifdef SPEEDY_SPEED_BOY
+#if UBER == 1
 	#define TSS_UNROLL [loop]
 #else
 	#define TSS_UNROLL [unroll(TEXTURE_STAGE_COUNT)]

--- a/d3d8to11/d3d8to11.hlsl
+++ b/d3d8to11/d3d8to11.hlsl
@@ -160,7 +160,7 @@ struct VS_OUTPUT
 };
 
 #if UBER == 1
-cbuffer PerSceneBuffer : register(b0)
+cbuffer UberBuffer : register(b0)
 {
 	bool rs_lighting;
 	bool rs_specular;

--- a/d3d8to11/d3d8to11.hlsl
+++ b/d3d8to11/d3d8to11.hlsl
@@ -506,7 +506,7 @@ float4 texture_op(uint color_op, float4 color_arg1, float4 color_arg2, float4 co
 		return color_arg2;
 	}
 
-	float4 result = (float4)0;
+	float4 result;
 
 	switch (color_op)
 	{
@@ -517,51 +517,63 @@ float4 texture_op(uint color_op, float4 color_arg1, float4 color_arg2, float4 co
 		case TOP_MODULATE:
 			result = color_arg1 * color_arg2;
 			break;
+
 		case TOP_MODULATE2X:
 			result = 2 * (color_arg1 * color_arg2);
 			break;
+
 		case TOP_MODULATE4X:
 			result = 4 * (color_arg1 * color_arg2);
 			break;
+
 		case TOP_ADD:
 			result = color_arg1 + color_arg2;
 			break;
+
 		case TOP_ADDSIGNED:
 			result = (color_arg1 + color_arg2) - 0.5;
 			break;
+
 		case TOP_ADDSIGNED2X:
 			result = 2 * ((color_arg1 + color_arg2) - 0.5);
 			break;
+
 		case TOP_SUBTRACT:
 			result = color_arg1 - color_arg2;
 			break;
+
 		case TOP_ADDSMOOTH:
 			result = (color_arg1 + color_arg2) - (color_arg1 * color_arg2);
 			break;
+
 		case TOP_BLENDDIFFUSEALPHA:
 		{
 			float alpha = in_diffuse.a;
 			result = (color_arg1 * alpha) + (color_arg2 * (1 - alpha));
 			break;
 		}
+
 		case TOP_BLENDTEXTUREALPHA:
 		{
 			float alpha = texel.a;
 			result = (color_arg1 * alpha) + (color_arg2 * (1 - alpha));
 			break;
 		}
+
 		case TOP_BLENDFACTORALPHA:
 		{
 			float alpha = texture_factor.a;
 			result = (color_arg1 * alpha) + (color_arg2 * (1 - alpha));
 			break;
 		}
+
 		case TOP_BLENDTEXTUREALPHAPM:
 		{
 			float alpha = texel.a;
 			result = color_arg1 + (color_arg2 * (1 - alpha));
 			break;
 		}
+
 		case TOP_BLENDCURRENTALPHA:
 		{
 			float alpha = current.a;
@@ -571,30 +583,31 @@ float4 texture_op(uint color_op, float4 color_arg1, float4 color_arg2, float4 co
 
 		case TOP_PREMODULATE: // TODO: NOT SUPPORTED
 			return float4(1, 0, 0, 1);
-			break;
 
 		case TOP_MODULATEALPHA_ADDCOLOR:
 			result = float4(color_arg1.rgb + (color_arg2.rgb * color_arg1.a), color_arg1.a * color_arg2.a);
 			break;
+
 		case TOP_MODULATECOLOR_ADDALPHA:
 			result = float4(color_arg1.rgb * color_arg2.rgb, color_arg1.a + color_arg2.a);
 			break;
+
 		case TOP_MODULATEINVALPHA_ADDCOLOR:
 			result = float4(color_arg1.rgb + (color_arg2.rgb * (1 - color_arg1.a)), color_arg1.a * color_arg2.a);
 			break;
+
 		case TOP_MODULATEINVCOLOR_ADDALPHA:
 			result = float4((1 - color_arg1.rgb) * color_arg2.rgb, color_arg1.a + color_arg2.a);
 			break;
 
 		case TOP_BUMPENVMAP: // TODO: NOT SUPPORTED
 			return float4(1, 0, 0, 1);
-			break;
+
 		case TOP_BUMPENVMAPLUMINANCE: // TODO: NOT SUPPORTED
 			return float4(1, 0, 0, 1);
-			break;
+
 		case TOP_DOTPRODUCT3: // TODO: NOT SUPPORTED
 			return float4(1, 0, 0, 1);
-			break;
 
 		case TOP_MULTIPLYADD:
 			result = color_arg1 + color_arg2 * color_arg0;
@@ -641,8 +654,13 @@ void get_input_colors(in VS_OUTPUT input, out float4 diffuse, out float4 specula
 #if defined(PIXEL_LIGHTING)
 	if (rs_lighting)
 	{
-		perform_lighting(input.ambient, input.diffuse, input.specular, input.w_position, normalize(input.w_normal),
-		                 diffuse, specular);
+		perform_lighting(input.ambient,
+		                 input.diffuse,
+		                 input.specular,
+		                 input.w_position,
+		                 normalize(input.w_normal),
+		                 diffuse,
+		                 specular);
 
 		diffuse = saturate(diffuse + input.emissive);
 	}

--- a/d3d8to11/d3d8to11.hlsl
+++ b/d3d8to11/d3d8to11.hlsl
@@ -582,7 +582,8 @@ float4 texture_op(uint color_op, float4 color_arg1, float4 color_arg2, float4 co
 		}
 
 		case TOP_PREMODULATE: // TODO: NOT SUPPORTED
-			return float4(1, 0, 0, 1);
+			result = float4(1, 0, 0, 1);
+			break;
 
 		case TOP_MODULATEALPHA_ADDCOLOR:
 			result = float4(color_arg1.rgb + (color_arg2.rgb * color_arg1.a), color_arg1.a * color_arg2.a);
@@ -601,13 +602,16 @@ float4 texture_op(uint color_op, float4 color_arg1, float4 color_arg2, float4 co
 			break;
 
 		case TOP_BUMPENVMAP: // TODO: NOT SUPPORTED
-			return float4(1, 0, 0, 1);
+			result = float4(1, 0, 0, 1);
+			break;
 
 		case TOP_BUMPENVMAPLUMINANCE: // TODO: NOT SUPPORTED
-			return float4(1, 0, 0, 1);
+			result = float4(1, 0, 0, 1);
+			break;
 
 		case TOP_DOTPRODUCT3: // TODO: NOT SUPPORTED
-			return float4(1, 0, 0, 1);
+			result = float4(1, 0, 0, 1);
+			break;
 
 		case TOP_MULTIPLYADD:
 			result = color_arg1 + color_arg2 * color_arg0;
@@ -819,7 +823,6 @@ void do_alpha_reject(float4 result, bool standard_blending)
 					clip(-1);
 				}
 			}
-
 		}
 		else
 		{
@@ -829,7 +832,6 @@ void do_alpha_reject(float4 result, bool standard_blending)
 				uint threshold = floor(alpha_reject_threshold * 255);
 				clip(compare(alpha_reject_mode, alpha, threshold) ? 1 : -1);
 			}
-
 		}
 	}
 }

--- a/d3d8to11/d3d8to11.hlsl
+++ b/d3d8to11/d3d8to11.hlsl
@@ -871,7 +871,7 @@ void get_colors(in VS_INPUT input, inout VS_OUTPUT result)
 {
 	if (color_vertex == true)
 	{
-		if (rs_lighting)
+		if (!rs_lighting)
 		{
 			#ifdef FVF_DIFFUSE
 				result.diffuse = input.diffuse;

--- a/d3d8to11/d3d8to11.vcxproj
+++ b/d3d8to11/d3d8to11.vcxproj
@@ -322,6 +322,8 @@ xcopy /C /Y /D "$(ProjectDir)composite.hlsl" "$(OutDir)"</Command>
     <ClInclude Include="not_implemented.h" />
     <ClInclude Include="safe_release.h" />
     <ClInclude Include="Shader.h" />
+    <ClInclude Include="ShaderCompilationQueue.h" />
+    <ClInclude Include="ShaderFlags.h" />
     <ClInclude Include="simple_math.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="typedefs.h" />
@@ -342,6 +344,8 @@ xcopy /C /Y /D "$(ProjectDir)composite.hlsl" "$(OutDir)"</Command>
     <ClCompile Include="globals.cpp" />
     <ClCompile Include="Light.cpp" />
     <ClCompile Include="Material.cpp" />
+    <ClCompile Include="ShaderCompilationQueue.cpp" />
+    <ClCompile Include="ShaderFlags.cpp" />
     <ClCompile Include="simple_math.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/d3d8to11/d3d8to11.vcxproj.filters
+++ b/d3d8to11/d3d8to11.vcxproj.filters
@@ -99,6 +99,12 @@
     <ClInclude Include="not_implemented.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ShaderCompilationQueue.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ShaderFlags.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -150,6 +156,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="globals.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ShaderCompilationQueue.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ShaderFlags.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/d3d8to11/d3d8to11_device.cpp
+++ b/d3d8to11/d3d8to11_device.cpp
@@ -945,14 +945,14 @@ void Direct3DDevice8::create_native()
 				}
 			}
 
-			OutputDebugStringA("waiting for uber shader compilation to finish...");
+			OutputDebugStringA("waiting for uber shader compilation to finish...\n");
 
 			while (shader_compilation_queue.enqueued_count())
 			{
 				std::this_thread::sleep_for(std::chrono::milliseconds(1));
 			}
 
-			OutputDebugStringA("done\nenqueueing standard shaders now...");
+			OutputDebugStringA("done\nenqueueing standard shaders now...\n");
 
 			{
 				_LOCK(permutation_mutex);

--- a/d3d8to11/d3d8to11_device.cpp
+++ b/d3d8to11/d3d8to11_device.cpp
@@ -9,9 +9,9 @@
 #include <DirectXMath.h>
 #include <cassert>
 #include <fstream>
-#include <optional>
 #include <sstream>
 #include <filesystem>
+#include <shared_mutex>
 
 #include "alignment.h"
 #include "CBufferWriter.h"
@@ -23,13 +23,13 @@
 #include "safe_release.h"
 #include "ShaderIncluder.h"
 #include "SimpleMath.h"
+#include "ShaderFlags.h"
 
 // TODO: provide a wrapper structure that can swap out render targets when OIT is toggled
 
 #define SHADER_ASYNC_COMPILE
-//#define SHADER_FAST_FALLBACK
 
-#define LOCK(MUTEX) std::lock_guard<decltype(MUTEX)> MUTEX ## _guard(MUTEX)
+#define _LOCK(MUTEX) std::lock_guard<decltype(MUTEX)> MUTEX ## _guard(MUTEX)
 
 using namespace Microsoft::WRL;
 using namespace d3d8to11;
@@ -159,7 +159,7 @@ size_t Direct3DDevice8::count_texture_stages() const
 
 static std::unordered_map<size_t, std::string> digit_strings;
 
-const std::vector<D3D_SHADER_MACRO>& Direct3DDevice8::shader_preprocess(ShaderFlags::type flags)
+const std::vector<D3D_SHADER_MACRO>& Direct3DDevice8::shader_preprocess(ShaderFlags::type flags, bool is_uber)
 {
 	static const std::array texcoord_size_strings = {
 		"FVF_TEXCOORD0_SIZE",
@@ -194,14 +194,14 @@ const std::vector<D3D_SHADER_MACRO>& Direct3DDevice8::shader_preprocess(ShaderFl
 	sanitized_flags &= ~ShaderFlags::stage_count_mask;
 	sanitized_flags |= (static_cast<ShaderFlags::type>(count_texture_stages()) << ShaderFlags::stage_count_shift) & ShaderFlags::stage_count_mask;
 
-	std::lock_guard shader_preproc_lock(shader_preproc_mutex);
+	//std::lock_guard shader_preproc_lock(shader_preproc_mutex);
 
-	const auto it = shader_preproc_definitions.find(sanitized_flags);
+	//const auto it = shader_preproc_definitions.find(sanitized_flags);
 
-	if (it != shader_preproc_definitions.end())
-	{
-		return it->second;
-	}
+	//if (it != shader_preproc_definitions.end())
+	//{
+	//	return it->second;
+	//}
 
 	std::vector<D3D_SHADER_MACRO> definitions
 	{
@@ -258,21 +258,30 @@ const std::vector<D3D_SHADER_MACRO>& Direct3DDevice8::shader_preprocess(ShaderFl
 
 	definitions.push_back({ "TEXTURE_STAGE_COUNT", digit_string->second.c_str() });
 
-	auto one_or_zero_value = [&](ShaderFlags::type mask, ShaderFlags::type value)
+	if ((sanitized_flags & D3DFVF_POSITION_MASK) == D3DFVF_XYZRHW)
 	{
-		return ((sanitized_flags & mask) == value) ? "1" : "0";
-	};
+		definitions.push_back({ "FVF_RHW", "1" });
+	}
 
-	auto one_or_zero = [&](ShaderFlags::type mask)
+	if ((sanitized_flags & D3DFVF_POSITION_MASK) == D3DFVF_XYZ)
 	{
-		return one_or_zero_value(mask, mask);
-	};
+		definitions.push_back({ "FVF_XYZ", "1" });
+	}
 
-	definitions.push_back({ "FVF_RHW", one_or_zero_value(D3DFVF_POSITION_MASK, D3DFVF_XYZRHW) });
-	definitions.push_back({ "FVF_XYZ", one_or_zero_value(D3DFVF_POSITION_MASK, D3DFVF_XYZ) });
-	definitions.push_back({ "FVF_NORMAL", one_or_zero(D3DFVF_NORMAL) });
-	definitions.push_back({ "FVF_DIFFUSE", one_or_zero(D3DFVF_DIFFUSE) });
-	definitions.push_back({ "FVF_SPECULAR", one_or_zero(D3DFVF_SPECULAR) });
+	if ((sanitized_flags & D3DFVF_NORMAL) != 0)
+	{
+		definitions.push_back({ "FVF_NORMAL", "1" });
+	}
+
+	if ((sanitized_flags & D3DFVF_DIFFUSE) != 0)
+	{
+		definitions.push_back({ "FVF_DIFFUSE", "1" });
+	}
+
+	if ((sanitized_flags & D3DFVF_SPECULAR) != 0)
+	{
+		definitions.push_back({ "FVF_SPECULAR", "1" });
+	}
 
 	if (sanitized_flags & D3DFVF_TEXCOUNT_MASK)
 	{
@@ -284,13 +293,25 @@ const std::vector<D3D_SHADER_MACRO>& Direct3DDevice8::shader_preprocess(ShaderFl
 		definitions.push_back({ "FVF_TEXCOUNT", "0" });
 	}
 
-	constexpr ShaderFlags::type lighting_mask = ShaderFlags::rs_lighting | D3DFVF_NORMAL;
+	auto one_or_zero = [&](ShaderFlags::type mask)
+	{
+		return (sanitized_flags & mask) != 0 ? "1" : "0";
+	};
 
-	definitions.push_back({ "RS_LIGHTING", one_or_zero_value(lighting_mask, lighting_mask) });
-	definitions.push_back({ "RS_SPECULAR", one_or_zero(ShaderFlags::rs_specular) });
-	definitions.push_back({ "RS_ALPHA", one_or_zero(ShaderFlags::rs_alpha) });
-	definitions.push_back({ "RS_FOG", one_or_zero(ShaderFlags::rs_fog) });
-	definitions.push_back({ "RS_OIT", one_or_zero(ShaderFlags::rs_oit) });
+	if (is_uber)
+	{
+		definitions.push_back({ "UBER", "1" });
+	}
+	else
+	{
+		definitions.push_back({ "UBER", "0" });
+
+		definitions.push_back({ "RS_LIGHTING", one_or_zero(ShaderFlags::rs_lighting) });
+		definitions.push_back({ "RS_SPECULAR", one_or_zero(ShaderFlags::rs_specular) });
+		definitions.push_back({ "RS_ALPHA", one_or_zero(ShaderFlags::rs_alpha) });
+		definitions.push_back({ "RS_FOG", one_or_zero(ShaderFlags::rs_fog) });
+		definitions.push_back({ "RS_OIT", one_or_zero(ShaderFlags::rs_oit) });
+	}
 
 	shader_preproc_definitions[sanitized_flags] = std::move(definitions);
 	return shader_preproc_definitions[sanitized_flags];
@@ -309,29 +330,14 @@ static constexpr auto SHADER_COMPILER_FLAGS =
 #endif
 ;
 
-VertexShader Direct3DDevice8::get_vs(ShaderFlags::type flags,
-                                     bool speedy_speed_boy,
-                                     std::unordered_map<ShaderFlags::type, VertexShader>& shaders,
-                                     std::recursive_mutex& mutex)
+VertexShader Direct3DDevice8::get_vs_internal(ShaderFlags::type flags,
+                                              std::unordered_map<ShaderFlags::type, VertexShader>& shaders,
+                                              std::shared_mutex& mutex,
+                                              bool is_uber)
 {
-	flags = ShaderFlags::sanitize(flags & ShaderFlags::vs_mask);
-
-	{
-		std::lock_guard<std::recursive_mutex> lock(mutex);
-
-		const auto it = shaders.find(flags);
-
-		if (it != shaders.end())
-		{
-			return it->second;
-		}
-	}
-
 	//printf(__FUNCTION__ " compiling vs: %04X (total: %u)\n", flags, vs_map.size() + 1);
 
-	auto preproc = shader_preprocess(flags);
-	preproc.push_back({ "SPEEDY_SPEED_BOY", speedy_speed_boy ? "1" : "0"});
-	
+	std::vector<D3D_SHADER_MACRO> preproc = shader_preprocess(flags, is_uber);
 	preproc.push_back({});
 
 	ComPtr<ID3DBlob> errors;
@@ -367,47 +373,33 @@ VertexShader Direct3DDevice8::get_vs(ShaderFlags::type flags,
 	}
 
 	{
-		std::lock_guard<std::recursive_mutex> lock(mutex);
+		std::unique_lock lock(mutex);
 
 		auto result = VertexShader(shader, blob);
 		shaders[flags] = result;
 
-		LOCK(permutation_mutex);
+		_LOCK(permutation_mutex);
 
 		if (permutation_cache.is_open() && !permutation_flags.contains(flags))
 		{
 			OutputDebugStringA("writing vs permutation to permutation file\n");
 			permutation_cache.write(reinterpret_cast<const char*>(&flags), sizeof(flags));
 			permutation_cache.flush();
+			permutation_flags.insert(flags);
 		}
 
 		return result;
 	}
 }
 
-PixelShader Direct3DDevice8::get_ps(ShaderFlags::type flags,
-                                    bool speedy_speed_boy,
-                                    std::unordered_map<ShaderFlags::type, PixelShader>& shaders,
-                                    std::recursive_mutex& mutex)
+PixelShader Direct3DDevice8::get_ps_internal(ShaderFlags::type flags,
+                                             std::unordered_map<ShaderFlags::type, PixelShader>& shaders,
+                                             std::shared_mutex& mutex,
+                                             bool is_uber)
 {
-	flags = ShaderFlags::sanitize(flags & ShaderFlags::ps_mask);
-
-	{
-		std::lock_guard<std::recursive_mutex> lock(mutex);
-
-		const auto it = shaders.find(flags);
-
-		if (it != shaders.end())
-		{
-			return it->second;
-		}
-	}
-
 	//printf(__FUNCTION__ " compiling ps: %04X (total: %u)\n", flags, shaders.size() + 1);
 
-	auto preproc = shader_preprocess(flags);
-	preproc.push_back({ "SPEEDY_SPEED_BOY", speedy_speed_boy ? "1" : "0" });
-	
+	std::vector<D3D_SHADER_MACRO> preproc = shader_preprocess(flags, is_uber);
 	preproc.push_back({});
 
 	ComPtr<ID3DBlob> errors;
@@ -443,22 +435,121 @@ PixelShader Direct3DDevice8::get_ps(ShaderFlags::type flags,
 	}
 
 	{
-		std::lock_guard<std::recursive_mutex> lock(mutex);
+		std::unique_lock lock(mutex);
 
 		auto result = PixelShader(shader, blob);
 		shaders[flags] = result;
 
-		LOCK(permutation_mutex);
+		_LOCK(permutation_mutex);
 
 		if (permutation_cache.is_open() && !permutation_flags.contains(flags))
 		{
 			OutputDebugStringA("writing ps permutation to permutation file\n");
 			permutation_cache.write(reinterpret_cast<const char*>(&flags), sizeof(flags));
 			permutation_cache.flush();
+			permutation_flags.insert(flags);
 		}
 
 		return result;
 	}
+}
+
+VertexShader Direct3DDevice8::get_vs(ShaderFlags::type flags, bool use_uber_shader_fallback)
+{
+	flags = ShaderFlags::sanitize(flags);
+
+	const auto base_flags = ShaderFlags::sanitize(flags & ShaderFlags::vs_mask);
+	const auto uber_flags = ShaderFlags::sanitize(flags & ShaderFlags::uber_vs_mask);
+
+	{
+		std::shared_lock lock(vs_mutex);
+
+		const auto it = vertex_shaders.find(base_flags);
+
+		if (it != vertex_shaders.end())
+		{
+			return it->second;
+		}
+	}
+
+	if (!use_uber_shader_fallback)
+	{
+		return get_vs_internal(base_flags, vertex_shaders, vs_mutex, false);
+	}
+
+	{
+		std::shared_lock lock(uber_vs_mutex);
+
+#ifdef SHADER_ASYNC_COMPILE
+		auto enqueue_function = [this](const ShaderCompilationQueueEntry& e)
+		{
+			get_vs_internal(e.flags, vertex_shaders, vs_mutex, false);
+		};
+
+		shader_compilation_queue.enqueue(ShaderCompilationType::vertex, base_flags, enqueue_function);
+#else
+		get_vs_internal(base_flags, vertex_shaders, vs_mutex, false);
+#endif
+
+		const auto it = uber_vertex_shaders.find(uber_flags);
+
+		if (it != uber_vertex_shaders.end())
+		{
+			return it->second;
+		}
+	}
+
+	auto result = get_vs_internal(uber_flags, uber_vertex_shaders, uber_vs_mutex, true);
+	return result;
+}
+
+PixelShader Direct3DDevice8::get_ps(ShaderFlags::type flags, bool use_uber_shader_fallback)
+{
+	flags = ShaderFlags::sanitize(flags);
+
+	const auto base_flags = ShaderFlags::sanitize(flags & ShaderFlags::ps_mask);
+	const auto uber_flags = ShaderFlags::sanitize(flags & ShaderFlags::uber_ps_mask);
+
+	{
+		std::shared_lock lock(ps_mutex);
+
+		const auto it = pixel_shaders.find(base_flags);
+
+		if (it != pixel_shaders.end())
+		{
+			return it->second;
+		}
+	}
+
+	if (!use_uber_shader_fallback)
+	{
+		return get_ps_internal(base_flags, pixel_shaders, ps_mutex, false);
+	}
+
+	{
+		std::shared_lock lock(uber_ps_mutex);
+
+#ifdef SHADER_ASYNC_COMPILE
+		auto enqueue_function = [this](const ShaderCompilationQueueEntry& e)
+		{
+			get_ps_internal(e.flags, pixel_shaders, ps_mutex, false);
+		};
+
+		shader_compilation_queue.enqueue(ShaderCompilationType::pixel, base_flags, enqueue_function);
+#else
+		get_ps_internal(base_flags, pixel_shaders, ps_mutex, false);
+#endif
+
+		const auto it = uber_pixel_shaders.find(uber_flags);
+
+		if (it != uber_pixel_shaders.end())
+		{
+			return it->second;
+		}
+	}
+
+	auto result = get_ps_internal(uber_flags, uber_pixel_shaders, uber_ps_mutex, true);
+	return result;
 }
 
 void Direct3DDevice8::create_depth_stencil()
@@ -804,10 +895,17 @@ void Direct3DDevice8::create_native()
 			{
 				ShaderFlags::type flags = 0;
 
+				auto start = file.tellg();
 				file.read(reinterpret_cast<char*>(&flags), sizeof(flags));
+				auto end = file.tellg();
+
+				if (end - start != sizeof(flags))
+				{
+					break;
+				}
 
 				{
-					LOCK(permutation_mutex);
+					_LOCK(permutation_mutex);
 					permutation_flags.insert(flags);
 				}
 
@@ -815,13 +913,10 @@ void Direct3DDevice8::create_native()
 				ss << "compiling: " << flags << "\n"; // because OutputDebugStringA doesn't like std::endl
 				OutputDebugStringA(ss.str().c_str());
 
-				//get_ps(flags & ShaderFlags::ps_mask, false, pixel_shaders, ps_mutex);
-				//get_vs(flags & ShaderFlags::vs_mask, false, vertex_shaders, vs_mutex);
-
 				VertexShader vs_dummy;
 				PixelShader ps_dummy;
 
-				compile_shaders(flags, vs_dummy, ps_dummy);
+				compile_shaders(flags, &vs_dummy, &ps_dummy);
 			}
 
 			OutputDebugStringA("done\n");
@@ -920,6 +1015,7 @@ void Direct3DDevice8::create_native()
 	FVF = 0;
 	FVF.mark();
 
+	uber_shader_flags.mark();
 	per_scene.mark();
 	per_model.mark();
 	per_pixel.mark();
@@ -929,23 +1025,6 @@ void Direct3DDevice8::create_native()
 	oit_init();
 
 	update();
-}
-
-ShaderFlags::type ShaderFlags::sanitize(type flags)
-{
-	flags &= mask;
-
-	if (flags & rs_lighting && !(flags & D3DFVF_NORMAL))
-	{
-		flags &= ~rs_lighting;
-	}
-
-	if (flags & rs_oit && !(flags & rs_alpha))
-	{
-		flags &= ~rs_oit;
-	}
-
-	return flags;
 }
 
 bool DepthStencilFlags::dirty() const
@@ -1046,7 +1125,8 @@ Direct3DDevice8::Direct3DDevice8(Direct3D8* d3d, UINT adapter, D3DDEVTYPE device
 	  focus_window(focus_window),
 	  behavior_flags(behavior_flags),
 	  present_params(parameters),
-	  d3d(d3d)
+	  d3d(d3d),
+	  shader_compilation_queue(std::thread::hardware_concurrency())
 {
 	fragments_str = std::to_string(globals::max_fragments);
 }
@@ -2864,7 +2944,7 @@ HRESULT STDMETHODCALLTYPE Direct3DDevice8::GetCurrentTexturePalette(UINT* pPalet
 
 void Direct3DDevice8::run_draw_prologues(const std::string& callback)
 {
-	const auto& preproc = shader_preprocess(shader_flags);
+	const auto& preproc = shader_preprocess(shader_flags, false); // WIP: assuming non-uber
 	for (auto& fn : draw_prologues[callback])
 	{
 		fn(preproc, shader_flags);
@@ -2873,7 +2953,7 @@ void Direct3DDevice8::run_draw_prologues(const std::string& callback)
 
 void Direct3DDevice8::run_draw_epilogues(const std::string& callback)
 {
-	const auto& preproc = shader_preprocess(shader_flags);
+	const auto& preproc = shader_preprocess(shader_flags, false); // WIP: assuming non-uber
 	for (auto& fn : draw_epilogues[callback])
 	{
 		fn(preproc, shader_flags);
@@ -3700,7 +3780,7 @@ bool Direct3DDevice8::update_input_layout()
 		return false;
 	}
 
-	auto vs = get_vs(shader_flags, true, vertex_speed_shaders, vs_speed_mutex);
+	VertexShader vs = get_vs(shader_flags, true);
 
 	ComPtr<ID3D11InputLayout> layout;
 
@@ -3722,6 +3802,22 @@ bool Direct3DDevice8::update_input_layout()
 	OutputDebugStringA(ss.str().c_str());
 
 	return true;
+}
+
+void Direct3DDevice8::commit_uber_shader_flags()
+{
+	if (!uber_shader_flags.dirty())
+	{
+		return;
+	}
+
+	D3D11_MAPPED_SUBRESOURCE mapped {};
+	context->Map(uber_shader_cbuffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
+
+	auto writer = CBufferWriter(reinterpret_cast<uint8_t*>(mapped.pData));
+	uber_shader_flags.write(writer);
+	context->Unmap(uber_shader_cbuffer.Get(), 0);
+	uber_shader_flags.clear();
 }
 
 void Direct3DDevice8::commit_per_pixel()
@@ -3842,88 +3938,7 @@ void Direct3DDevice8::update_sampler()
 	}
 }
 
-std::optional<PixelShader> Direct3DDevice8::get_ps_async(ShaderFlags::type flags)
-{
-	flags = ShaderFlags::sanitize(flags & ShaderFlags::ps_mask);
-
-	{
-		LOCK(ps_tasks_mutex);
-
-		auto task_it = ps_tasks.find(flags);
-
-		if (task_it != ps_tasks.end())
-		{
-			auto status = task_it->second.wait_for(std::chrono::milliseconds(0));
-
-			if (status == std::future_status::ready)
-			{
-				auto result = task_it->second.get();
-				ps_tasks.erase(task_it);
-				return result;
-			}
-
-			return std::nullopt;
-		}
-
-		// clean
-		for (auto it = ps_tasks.begin(); it != ps_tasks.end();)
-		{
-			auto status = it->second.wait_for(std::chrono::milliseconds(0));
-
-			if (status == std::future_status::ready)
-			{
-				if (it->first != flags)
-				{
-					it = ps_tasks.erase(it);
-				}
-				else
-				{
-					auto result = it->second.get();
-					ps_tasks.erase(it);
-					return result;
-				}
-			}
-			else
-			{
-				++it;
-			}
-		}
-	}
-
-	{
-		LOCK(ps_mutex);
-
-		const auto ps_it = pixel_shaders.find(flags);
-
-		if (ps_it != pixel_shaders.end())
-		{
-			LOCK(ps_tasks_mutex);
-			ps_tasks.erase(ps_it->first);
-			return ps_it->second;
-		}
-	}
-
-	{
-		LOCK(ps_tasks_mutex);
-
-		if (ps_tasks.size() >= std::thread::hardware_concurrency())
-		{
-			//OutputDebugStringA("PS TASK COUNT REACHED HARDWARE LIMIT\n");
-			return std::nullopt;
-		}
-
-		auto task = std::async(std::launch::async, [this, flags]() -> auto
-		{
-			return get_ps(flags, false, pixel_shaders, ps_mutex);
-		});
-
-		ps_tasks[flags] = std::move(task);
-	}
-
-	return std::nullopt;
-}
-
-void Direct3DDevice8::compile_shaders(ShaderFlags::type flags, VertexShader& vs, PixelShader& ps)
+void Direct3DDevice8::compile_shaders(ShaderFlags::type flags, VertexShader* vs, PixelShader* ps)
 {
 	int result;
 
@@ -3931,25 +3946,8 @@ void Direct3DDevice8::compile_shaders(ShaderFlags::type flags, VertexShader& vs,
 	{
 		try
 		{
-			vs = get_vs(flags, false, vertex_shaders, vs_mutex);
-
-		#ifdef SHADER_ASYNC_COMPILE
-			auto ps_async = get_ps_async(flags);
-
-			if (ps_async.has_value())
-			{
-				ps = ps_async.value();
-			}
-			#ifdef SHADER_FAST_FALLBACK
-			else
-			{
-				ps = get_ps(flags, true, pixel_shaders, ps_speed_mutex);
-			}
-			#endif
-		#else
-			ps = get_ps(flags, true, pixel_shaders, ps_speed_mutex);
-		#endif
-
+			*vs = get_vs(flags, true);
+			*ps = get_ps(flags, true);
 			break;
 		}
 		catch (std::exception& ex)
@@ -3972,7 +3970,13 @@ void Direct3DDevice8::update_shaders()
 
 	shader_flags = ShaderFlags::sanitize(shader_flags);
 
-	shader_preprocess(shader_flags);
+	uber_shader_flags.rs_lighting = (shader_flags & ShaderFlags::rs_lighting) != 0;
+	uber_shader_flags.rs_specular = (shader_flags & ShaderFlags::rs_specular) != 0;
+	uber_shader_flags.rs_alpha    = (shader_flags & ShaderFlags::rs_alpha) != 0;
+	uber_shader_flags.rs_fog      = (shader_flags & ShaderFlags::rs_fog) != 0;
+	uber_shader_flags.rs_oit      = (shader_flags & ShaderFlags::rs_oit) != 0;
+
+	commit_uber_shader_flags();
 
 	if (last_shader_flags == shader_flags)
 	{
@@ -3982,27 +3986,21 @@ void Direct3DDevice8::update_shaders()
 	VertexShader vs;
 	PixelShader ps;
 
-	compile_shaders(shader_flags, vs, ps);
+	compile_shaders(shader_flags, &vs, &ps);
 
-	if ((shader_flags & ShaderFlags::vs_mask) != (last_shader_flags & ShaderFlags::vs_mask))
+	if (vs != current_vs)
 	{
 		context->VSSetShader(vs.shader.Get(), nullptr, 0);
+		current_vs = vs;
 	}
 
-	if ((shader_flags & ShaderFlags::ps_mask) != (last_shader_flags & ShaderFlags::ps_mask))
+	if (ps != current_ps)
 	{
 		context->PSSetShader(ps.shader.Get(), nullptr, 0);
+		current_ps = ps;
 	}
 
 	last_shader_flags = shader_flags;
-
-	if (!ps.has_value())
-	{
-		last_shader_flags &= ShaderFlags::ps_mask;
-	}
-
-	current_vs = vs;
-	current_ps = ps;
 }
 
 void Direct3DDevice8::update_blend()
@@ -4183,19 +4181,16 @@ bool Direct3DDevice8::skip_draw() const
 
 void Direct3DDevice8::free_shaders()
 {
+	shader_compilation_queue.shutdown();
+	shader_compilation_queue.start();
+
 	last_shader_flags = ShaderFlags::mask;
 
-	LOCK(ps_tasks_mutex);
-	ps_tasks.clear();
-
-	LOCK(vs_tasks_mutex);
-	vs_tasks.clear();
-
-	LOCK(shader_sources_mutex);
-	LOCK(vs_mutex);
-	LOCK(vs_speed_mutex);
-	LOCK(ps_mutex);
-	LOCK(ps_speed_mutex);
+	_LOCK(shader_sources_mutex);
+	std::unique_lock vs_lock(vs_mutex);
+	std::unique_lock ps_lock(ps_mutex);
+	std::unique_lock uber_vs_lock(uber_vs_mutex);
+	std::unique_lock uber_ps_lock(uber_ps_mutex);
 
 	current_vs = {};
 	current_ps = {};
@@ -4203,8 +4198,8 @@ void Direct3DDevice8::free_shaders()
 	shader_sources.clear();
 	vertex_shaders.clear();
 	pixel_shaders.clear();
-	vertex_speed_shaders.clear();
-	pixel_speed_shaders.clear();
+	uber_vertex_shaders.clear();
+	uber_pixel_shaders.clear();
 
 	fvf_layouts.clear();
 
@@ -4221,6 +4216,7 @@ void Direct3DDevice8::free_shaders()
 		pair.second.mark();
 	}
 
+	uber_shader_flags.mark();
 	per_model.mark();
 	per_pixel.mark();
 	per_scene.mark();

--- a/d3d8to11/d3d8to11_device.cpp
+++ b/d3d8to11/d3d8to11_device.cpp
@@ -3994,7 +3994,7 @@ void Direct3DDevice8::update_sampler()
 	}
 }
 
-void Direct3DDevice8::compile_shaders(ShaderFlags::type flags, VertexShader* vs, PixelShader* ps)
+void Direct3DDevice8::get_shaders(ShaderFlags::type flags, VertexShader* vs, PixelShader* ps)
 {
 	int result;
 
@@ -4042,7 +4042,7 @@ void Direct3DDevice8::update_shaders()
 	VertexShader vs;
 	PixelShader ps;
 
-	compile_shaders(shader_flags, &vs, &ps);
+	get_shaders(shader_flags, &vs, &ps);
 
 	if (vs != current_vs)
 	{

--- a/d3d8to11/d3d8to11_device.cpp
+++ b/d3d8to11/d3d8to11_device.cpp
@@ -188,9 +188,7 @@ std::vector<D3D_SHADER_MACRO> Direct3DDevice8::shader_preprocess(ShaderFlags::ty
 		"float1",
 	};
 
-	auto sanitized_flags = ShaderFlags::sanitize(flags);
-	sanitized_flags &= ~ShaderFlags::stage_count_mask;
-	sanitized_flags |= (static_cast<ShaderFlags::type>(count_texture_stages()) << ShaderFlags::stage_count_shift) & ShaderFlags::stage_count_mask;
+	const ShaderFlags::type sanitized_flags = ShaderFlags::sanitize(flags);
 
 	std::vector<D3D_SHADER_MACRO> definitions
 	{

--- a/d3d8to11/d3d8to11_device.h
+++ b/d3d8to11/d3d8to11_device.h
@@ -313,10 +313,8 @@ public:
 
 	void print_info_queue() const;
 
-	std::recursive_mutex shader_preproc_mutex;
-	std::unordered_map<ShaderFlags::type, std::vector<D3D_SHADER_MACRO>> shader_preproc_definitions;
 	[[nodiscard]] size_t count_texture_stages() const;
-	const std::vector<D3D_SHADER_MACRO>& shader_preprocess(ShaderFlags::type flags, bool is_uber);
+	std::vector<D3D_SHADER_MACRO> shader_preprocess(ShaderFlags::type flags, bool is_uber);
 
 	void draw_call_increment();
 

--- a/d3d8to11/d3d8to11_device.h
+++ b/d3d8to11/d3d8to11_device.h
@@ -91,8 +91,8 @@ namespace std
 		{
 			size_t h = std::hash<size_t>()(s.flags.data());
 
-			hash_combine(h, (size_t)s.depth_flags.data());
-			hash_combine(h, (size_t)s.stencil_flags.data());
+			hash_combine(h, static_cast<size_t>(s.depth_flags.data()));
+			hash_combine(h, static_cast<size_t>(s.stencil_flags.data()));
 
 			return h;
 		}
@@ -341,7 +341,7 @@ public:
 	void commit_per_scene();
 	void commit_per_texture();
 	void update_sampler();
-	void compile_shaders(ShaderFlags::type flags, VertexShader* vs, PixelShader* ps);
+	void get_shaders(ShaderFlags::type flags, VertexShader* vs, PixelShader* ps);
 	void update_shaders();
 	void update_blend();
 	void update_depth();

--- a/d3d8to11/d3d8to11_device.h
+++ b/d3d8to11/d3d8to11_device.h
@@ -185,8 +185,11 @@ class Direct3DDevice8 : public Unknown
 	std::recursive_mutex shader_sources_mutex;
 	std::unordered_map<std::string, std::vector<uint8_t>> shader_sources;
 	std::vector<uint8_t> trifan_buffer;
-	std::string texcount_str;
-	std::string fragments_str;
+
+	std::unordered_map<size_t, std::string> digit_strings;
+
+	const std::string fragments_str;
+
 	bool freeing_shaders = false;
 
 	UINT adapter;
@@ -314,7 +317,7 @@ public:
 	void print_info_queue() const;
 
 	[[nodiscard]] size_t count_texture_stages() const;
-	std::vector<D3D_SHADER_MACRO> shader_preprocess(ShaderFlags::type flags, bool is_uber);
+	std::vector<D3D_SHADER_MACRO> shader_preprocess(ShaderFlags::type flags, bool is_uber) const;
 
 	void draw_call_increment();
 

--- a/d3d8to11/defs.h
+++ b/d3d8to11/defs.h
@@ -1,8 +1,10 @@
 #pragma once
 
-constexpr auto LIGHT_COUNT           = 8;
-constexpr auto FVF_TEXCOORD_MAX      = 8;
-constexpr auto MAX_FRAGMENTS_DEFAULT = 32;
+#include <cstdint>
 
-// preprocessor because reasons
+constexpr size_t LIGHT_COUNT           = 8;
+constexpr size_t FVF_TEXCOORD_MAX      = 8;
+constexpr size_t MAX_FRAGMENTS_DEFAULT = 32;
+
+// preprocessor definition is used so that we can stringify this
 #define TEXTURE_STAGE_MAX 8

--- a/d3d8to11/shader.hlsl
+++ b/d3d8to11/shader.hlsl
@@ -1,6 +1,8 @@
 #define NODE_WRITE
 #include "d3d8to11.hlsl"
 
+//#define UBER_DEMO_MODE
+
 VS_OUTPUT vs_main(VS_INPUT input)
 {
 	return fixed_func_vs(input);
@@ -21,7 +23,7 @@ float4 ps_main(VS_OUTPUT input) : SV_TARGET
 	do_alpha_reject(result, standard_blending);
 	do_oit(result, input, standard_blending);
 
-#if UBER == 1
+#if UBER == 1 && defined(UBER_DEMO_MODE)
 	result.rgb = float3(1, 0, 0);
 #endif
 

--- a/d3d8to11/shader.hlsl
+++ b/d3d8to11/shader.hlsl
@@ -3,12 +3,21 @@
 
 VS_OUTPUT vs_main(VS_INPUT input)
 {
+#if UBER == 1
+	VS_OUTPUT result = fixed_func_vs(input);
+	result.diffuse.rgb = float3(0, 1, 0);
+	result.specular.rgb = float3(0, 1, 0);
+	return result;
+#else
 	return fixed_func_vs(input);
+#endif
 }
 
-#if !defined(RS_OIT) && !defined(RS_ALPHA)
-[earlydepthstencil]
-#endif
+//#if (!defined(UBER) || UBER == 0) && \
+//	(!defined(RS_OIT) || RS_OIT == 0) && \
+//	(!defined(RS_ALPHA) || RS_ALPHA == 0)
+//[earlydepthstencil]
+//#endif
 float4 ps_main(VS_OUTPUT input) : SV_TARGET
 {
 	float4 diffuse;
@@ -19,12 +28,17 @@ float4 ps_main(VS_OUTPUT input) : SV_TARGET
 	float4 result;
 
 	result = handle_texture_stages(input, diffuse, specular);
+
 	result = apply_fog(result, input.fog);
 
 	bool standard_blending = is_standard_blending();
 
 	do_alpha_reject(result, standard_blending);
 	do_oit(result, input, standard_blending);
+
+#if UBER == 1
+	result.rgb = float3(1, 0, 0);
+#endif
 
 	return result;
 }

--- a/d3d8to11/shader.hlsl
+++ b/d3d8to11/shader.hlsl
@@ -3,21 +3,9 @@
 
 VS_OUTPUT vs_main(VS_INPUT input)
 {
-#if UBER == 1
-	VS_OUTPUT result = fixed_func_vs(input);
-	result.diffuse.rgb = float3(0, 1, 0);
-	result.specular.rgb = float3(0, 1, 0);
-	return result;
-#else
 	return fixed_func_vs(input);
-#endif
 }
 
-//#if (!defined(UBER) || UBER == 0) && \
-//	(!defined(RS_OIT) || RS_OIT == 0) && \
-//	(!defined(RS_ALPHA) || RS_ALPHA == 0)
-//[earlydepthstencil]
-//#endif
 float4 ps_main(VS_OUTPUT input) : SV_TARGET
 {
 	float4 diffuse;
@@ -25,13 +13,10 @@ float4 ps_main(VS_OUTPUT input) : SV_TARGET
 
 	get_input_colors(input, diffuse, specular);
 
-	float4 result;
-
-	result = handle_texture_stages(input, diffuse, specular);
-
+	float4 result = handle_texture_stages(input, diffuse, specular);
 	result = apply_fog(result, input.fog);
 
-	bool standard_blending = is_standard_blending();
+	const bool standard_blending = is_standard_blending();
 
 	do_alpha_reject(result, standard_blending);
 	do_oit(result, input, standard_blending);

--- a/d3d8to11/stdafx.h
+++ b/d3d8to11/stdafx.h
@@ -19,6 +19,8 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <shared_mutex>
+#include <mutex>
 
 // Windows
 #include <Windows.h>
@@ -42,6 +44,7 @@
 #include "alignment.h"
 #include "cbuffers.h"
 #include "CBufferWriter.h"
+#include "ShaderFlags.h"
 #include "d3d8to11.hpp"
 #include "d3d8to11_base.h"
 #include "d3d8to11_device.h"


### PR DESCRIPTION
Good news:

These shaders compile very fast and give the more optimized shaders more time to compile in the background. This is a significant boost to startup and runtime performance.

Bad news:

They still require permutations due to the nature of D3D11 input layouts (FVF flags), so they're not quite as _uber_ as one might imagine.