### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,9 @@ version: 1.0.{build}-{branch}
 pull_requests:
   do_not_increment_build_number: true
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 platform:
   - x86
-  - x64
 configuration: Release
 
 install:


### PR DESCRIPTION
Fixes CI builds. Upgraded the image to Visual Studio 2022 to match the solution, and removed the x64 platform target.